### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/324/91/85632491.geojson
+++ b/data/856/324/91/85632491.geojson
@@ -889,6 +889,10 @@
     },
     "wof:country":"BB",
     "wof:country_alpha3":"BRB",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"7e58e9b5d64ace75333a4c19c98ea43a",
     "wof:hierarchy":[
         {
@@ -903,7 +907,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566605820,
+    "wof:lastmodified":1582319512,
     "wof:name":"Barbados",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/857/934/91/85793491.geojson
+++ b/data/857/934/91/85793491.geojson
@@ -71,6 +71,9 @@
         "qs:id":1082566
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bf56813fe12c249b48d6da3861976e8",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379234,
+    "wof:lastmodified":1582319512,
     "wof:name":"Brighton",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/934/95/85793495.geojson
+++ b/data/857/934/95/85793495.geojson
@@ -96,6 +96,9 @@
         "gp:id":56362
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf1c6731f45dca59c78fb0385ffc95a9",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605819,
+    "wof:lastmodified":1582319512,
     "wof:name":"Cheapside",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/03/85793503.geojson
+++ b/data/857/935/03/85793503.geojson
@@ -257,6 +257,10 @@
         "wd:id":"Q161944"
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4ea10fb73a26f80e4e0e97cdf769012",
     "wof:hierarchy":[
         {
@@ -271,7 +275,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605818,
+    "wof:lastmodified":1582319512,
     "wof:name":"Deacons",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/05/85793505.geojson
+++ b/data/857/935/05/85793505.geojson
@@ -147,6 +147,10 @@
         "qs_pg:id":1174366
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c9a1561e65b938189bc50aa782685e8e",
     "wof:hierarchy":[
         {
@@ -161,7 +165,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605818,
+    "wof:lastmodified":1582319512,
     "wof:name":"Fairfield",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/09/85793509.geojson
+++ b/data/857/935/09/85793509.geojson
@@ -63,6 +63,9 @@
         "gp:id":56503
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"840840d578022d693693ac8fc4ebba82",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605818,
+    "wof:lastmodified":1582319512,
     "wof:name":"Henrys",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/13/85793513.geojson
+++ b/data/857/935/13/85793513.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":211022
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bcb72546e0939ec96ea79c2d1d211948",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605818,
+    "wof:lastmodified":1582319512,
     "wof:name":"Station Hill",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/935/19/85793519.geojson
+++ b/data/857/935/19/85793519.geojson
@@ -139,6 +139,9 @@
         "qs_pg:id":1113349
     },
     "wof:country":"BB",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9868cc89db9f746b76608e8a04750b0b",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566605818,
+    "wof:lastmodified":1582319512,
     "wof:name":"Weymouth",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/452/811/890452811.geojson
+++ b/data/890/452/811/890452811.geojson
@@ -412,6 +412,9 @@
     },
     "wof:country":"BB",
     "wof:created":1469052830,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"2479aeea34fcccce6a46855a2584602d",
     "wof:hierarchy":[
         {
@@ -422,7 +425,7 @@
         }
     ],
     "wof:id":890452811,
-    "wof:lastmodified":1566605839,
+    "wof:lastmodified":1582319513,
     "wof:name":"Bridgetown",
     "wof:parent_id":85669465,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.