### PR TITLE
bb concordances, placetype local, and more

### DIFF
--- a/data/856/324/91/85632491.geojson
+++ b/data/856/324/91/85632491.geojson
@@ -1086,6 +1086,7 @@
         "hasc:id":"BB",
         "icao:code":"8P",
         "ioc:id":"BAR",
+        "iso:code":"BB",
         "itu:id":"BRB",
         "m49:code":"052",
         "marc:id":"bb",
@@ -1099,6 +1100,7 @@
         "wk:page":"Barbados",
         "wmo:id":"BR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
     "wof:country_alpha3":"BRB",
     "wof:geom_alt":[
@@ -1119,7 +1121,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639667,
+    "wof:lastmodified":1695881327,
     "wof:name":"Barbados",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/694/35/85669435.geojson
+++ b/data/856/694/35/85669435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004787,
-    "geom:area_square_m":57651672.327976,
+    "geom:area_square_m":57651454.895459,
     "geom:bbox":"-59.600243,13.051174,-59.475776,13.129431",
     "geom:latitude":13.090966,
     "geom:longitude":-59.529484,
@@ -285,14 +285,16 @@
         "gn:id":3373988,
         "gp:id":2344730,
         "hasc:id":"BB.CC",
+        "iso:code":"BB-01",
         "iso:id":"BB-01",
         "qs_pg:id":222803,
         "unlc:id":"BB-01",
         "wd:id":"Q1626524",
         "wk:page":"Christ Church, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"a96761ad8451d394f78b8afbc726b3dd",
+    "wof:geomhash":"249c326512558c3d4996a35d385ec8aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855918,
+    "wof:lastmodified":1695884837,
     "wof:name":"Christ Church",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/39/85669439.geojson
+++ b/data/856/694/39/85669439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003004,
-    "geom:area_square_m":36156379.606492,
+    "geom:area_square_m":36156299.095837,
     "geom:bbox":"-59.606046,13.20984,-59.54581,13.289672",
     "geom:latitude":13.253025,
     "geom:longitude":-59.581887,
@@ -283,14 +283,16 @@
         "gn:id":3373580,
         "gp:id":2344731,
         "hasc:id":"BB.AN",
+        "iso:code":"BB-02",
         "iso:id":"BB-02",
         "qs_pg:id":222804,
         "unlc:id":"BB-02",
         "wd:id":"Q1647439",
         "wk:page":"Saint Andrew, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"bcf2dc0a23bf8c781f078353bd946cf8",
+    "wof:geomhash":"a1769da494b5fc522eff90836634973c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855920,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/45/85669445.geojson
+++ b/data/856/694/45/85669445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00368,
-    "geom:area_square_m":44311966.375412,
+    "geom:area_square_m":44312312.477466,
     "geom:bbox":"-59.587107,13.108192,-59.508714,13.182503",
     "geom:latitude":13.146131,
     "geom:longitude":-59.548349,
@@ -283,14 +283,16 @@
         "gn:id":3373572,
         "gp:id":2344732,
         "hasc:id":"BB.GE",
+        "iso:code":"BB-03",
         "iso:id":"BB-03",
         "qs_pg:id":452973,
         "unlc:id":"BB-03",
         "wd:id":"Q1647443",
         "wk:page":"Saint George, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"dbfd9746bba0ab7fe81d29730a069768",
+    "wof:geomhash":"b5409831751fa6348547da257e3b3c4a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855919,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint George",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/49/85669449.geojson
+++ b/data/856/694/49/85669449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003545,
-    "geom:area_square_m":42677594.548293,
+    "geom:area_square_m":42677727.00861,
     "geom:bbox":"-59.650806,13.136408,-59.601033,13.244928",
     "geom:latitude":13.196755,
     "geom:longitude":-59.62915,
@@ -289,14 +289,16 @@
         "gn:id":3373570,
         "gp:id":2344733,
         "hasc:id":"BB.JM",
+        "iso:code":"BB-04",
         "iso:id":"BB-04",
         "qs_pg:id":222805,
         "unlc:id":"BB-04",
         "wd:id":"Q592141",
         "wk:page":"Saint James, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"bff1312409edbc7eb23a778238ca1ffe",
+    "wof:geomhash":"d26501331272d83e1ebb8a8e91fe0654",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855920,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint James",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/51/85669451.geojson
+++ b/data/856/694/51/85669451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002604,
-    "geom:area_square_m":31345802.760652,
+    "geom:area_square_m":31345775.308165,
     "geom:bbox":"-59.54021,13.145761,-59.46768,13.217513",
     "geom:latitude":13.184317,
     "geom:longitude":-59.508598,
@@ -280,14 +280,16 @@
         "gn:id":3373569,
         "gp:id":2344734,
         "hasc:id":"BB.JN",
+        "iso:code":"BB-05",
         "iso:id":"BB-05",
         "qs_pg:id":222806,
         "unlc:id":"BB-05",
         "wd:id":"Q1626540",
         "wk:page":"Saint John, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"bb3e59963ccdfa7cf190395b5403fc15",
+    "wof:geomhash":"e44f110d7ec48fba9de0c40a66cecb06",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -302,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855919,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint John",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/57/85669457.geojson
+++ b/data/856/694/57/85669457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002104,
-    "geom:area_square_m":25321652.656823,
+    "geom:area_square_m":25321652.656826,
     "geom:bbox":"-59.580983,13.180074,-59.518053,13.243798",
     "geom:latitude":13.214047,
     "geom:longitude":-59.551468,
@@ -289,14 +289,16 @@
         "gn:id":3373568,
         "gp:id":2344735,
         "hasc:id":"BB.JS",
+        "iso:code":"BB-06",
         "iso:id":"BB-06",
         "qs_pg:id":236169,
         "unlc:id":"BB-06",
         "wd:id":"Q550249",
         "wk:page":"Saint Joseph, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"377536506df56c2ee14c64668deffe25",
+    "wof:geomhash":"64fb00f16b151b48cc59bafe1e2a2336",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855918,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Joseph",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/59/85669459.geojson
+++ b/data/856/694/59/85669459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00315,
-    "geom:area_square_m":37899677.032193,
+    "geom:area_square_m":37899834.71378,
     "geom:bbox":"-59.654205,13.273861,-59.575919,13.34455",
     "geom:latitude":13.311532,
     "geom:longitude":-59.619887,
@@ -277,14 +277,16 @@
         "gn:id":3373565,
         "gp:id":2344736,
         "hasc:id":"BB.LU",
+        "iso:code":"BB-07",
         "iso:id":"BB-07",
         "qs_pg:id":1060665,
         "unlc:id":"BB-07",
         "wd:id":"Q1647447",
         "wk:page":"Saint Lucy, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"dae1c55ef1739f4f723ab374ae1f09b3",
+    "wof:geomhash":"0e358892333ce3006206ebf05a37f2cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855918,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Lucy",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/65/85669465.geojson
+++ b/data/856/694/65/85669465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003344,
-    "geom:area_square_m":40264364.030598,
+    "geom:area_square_m":40264061.57024,
     "geom:bbox":"-59.640607,13.084133,-59.568839,13.161316",
     "geom:latitude":13.119707,
     "geom:longitude":-59.602571,
@@ -316,14 +316,16 @@
         "gn:id":3373557,
         "gp:id":2344737,
         "hasc:id":"BB.MI",
+        "iso:code":"BB-08",
         "iso:id":"BB-08",
         "qs_pg:id":1083799,
         "unlc:id":"BB-08",
         "wd:id":"Q819170",
         "wk:page":"Saint Michael, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"221b8e5882d4ca636ccab9cc3010ee79",
+    "wof:geomhash":"5e56bcaac4a5f9e63549eaa4cb1afe1d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855920,
+    "wof:lastmodified":1695884325,
     "wof:name":"Saint Michael",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/69/85669469.geojson
+++ b/data/856/694/69/85669469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002529,
-    "geom:area_square_m":30439202.355008,
+    "geom:area_square_m":30439202.355029,
     "geom:bbox":"-59.652921,13.237229,-59.568965,13.304393",
     "geom:latitude":13.269767,
     "geom:longitude":-59.619858,
@@ -295,14 +295,16 @@
         "gn:id":3373554,
         "gp:id":2344738,
         "hasc:id":"BB.PE",
+        "iso:code":"BB-09",
         "iso:id":"BB-09",
         "qs_pg:id":219500,
         "unlc:id":"BB-09",
         "wd:id":"Q932723",
         "wk:page":"Saint Peter, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"c9e85e294a4ca6172c01db236b08dabd",
+    "wof:geomhash":"1bfcd9012720398f11d81f5ec4956eeb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855919,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/73/85669473.geojson
+++ b/data/856/694/73/85669473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005392,
-    "geom:area_square_m":64931672.595846,
+    "geom:area_square_m":64931540.749639,
     "geom:bbox":"-59.513106,13.086495,-59.42691,13.186538",
     "geom:latitude":13.138206,
     "geom:longitude":-59.467338,
@@ -286,14 +286,16 @@
         "gn:id":3373553,
         "gp:id":2344739,
         "hasc:id":"BB.PH",
+        "iso:code":"BB-10",
         "iso:id":"BB-10",
         "qs_pg:id":423564,
         "unlc:id":"BB-10",
         "wd:id":"Q1647436",
         "wk:page":"Saint Philip, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"1491ff0325ce3f4dfb9f5bef9d1cc216",
+    "wof:geomhash":"f03d2e328d3a0b585b3a179310fa4e23",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -308,7 +310,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855919,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Philip",
     "wof:parent_id":85632491,
     "wof:placetype":"region",

--- a/data/856/694/77/85669477.geojson
+++ b/data/856/694/77/85669477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002902,
-    "geom:area_square_m":34937414.174999,
+    "geom:area_square_m":34937479.627748,
     "geom:bbox":"-59.625296,13.150257,-59.554292,13.217023",
     "geom:latitude":13.18478,
     "geom:longitude":-59.59179,
@@ -284,14 +284,16 @@
         "gn:id":3373551,
         "gp:id":2344740,
         "hasc:id":"BB.TH",
+        "iso:code":"BB-11",
         "iso:id":"BB-11",
         "qs_pg:id":219501,
         "unlc:id":"BB-11",
         "wd:id":"Q1647432",
         "wk:page":"Saint Thomas, Barbados"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BB",
-    "wof:geomhash":"557882393ca7f2c95a872e99e36d28e6",
+    "wof:geomhash":"7da8dcd9e5abbe3213691ac979471a00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690855920,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632491,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.